### PR TITLE
Export default styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,14 @@ import FileIcon from 'react-file-icon';
 | `radius`          | number | 4          | Corner radius of the file icon    |
 | `size`            | number | undefined  | Width and height of the file icon |
 | `type`            | enum   | undefined  | Type of glyph icon to display (One of: 3d, acrobat, audio, binary, code, compressed, document, drive, font, image, presentation, settings, spreadsheet, vector, video) |
+
+## Default Styles
+
+We also export an object of [default styles](https://github.com/pixelunion/react-file-icon/blob/master/src/components/defaultStyles/index.js) that can be used as a starting point when rendering icons. Object keys map to file extensions.
+
+```js
+import FileIcon, { defaultStyles } from 'react-file-icon';
+
+// Render a .docx icon with default styles
+<FileIcon extension="docx" {...defaultStyles.docx} />
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-file-icon",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/FileIcon.md
+++ b/src/components/FileIcon.md
@@ -23,7 +23,9 @@ Sizing
 
 ```js
 const icons = [72, 60, 48, 36, 24, 16].map((size, i) => {
-  return <FileIcon size={size} type="code" extension="jsx" labelUppercase key={i} />;
+  return (
+    <FileIcon size={size} type="code" extension="jsx" labelUppercase key={i} />
+  );
 });
 <div style={{ WebkitFontSmoothing: 'antialiased' }}>{icons}</div>;
 ```
@@ -57,7 +59,15 @@ const icons = [
   'deepskyblue',
   'orchid'
 ].map((color, i) => {
-  return <FileIcon size={48} extension="mp3" labelColor={color} labelUppercase  key={i} />;
+  return (
+    <FileIcon
+      size={48}
+      extension="mp3"
+      labelColor={color}
+      labelUppercase
+      key={i}
+    />
+  );
 });
 <div style={{ WebkitFontSmoothing: 'antialiased' }}>{icons}</div>;
 ```

--- a/src/components/defaultStyles/index.js
+++ b/src/components/defaultStyles/index.js
@@ -1,0 +1,371 @@
+export default {
+  '3dm': {
+    type: '3d'
+  },
+  '3ds': {
+    type: '3d'
+  },
+  '3g2': {
+    type: 'video'
+  },
+  '3gp': {
+    type: 'video'
+  },
+  '7zip': {
+    type: 'compressed'
+  },
+  aac: {
+    type: 'audio'
+  },
+  aep: {
+    type: 'video'
+  },
+  ai: {
+    color: '#423325',
+    gradientOpacity: 0,
+    labelColor: '#423325',
+    labelTextColor: '#FF7F18',
+    labelUppercase: true,
+    foldColor: '#FF7F18',
+    radius: 2
+  },
+  aif: {
+    type: 'audio'
+  },
+  aiff: {
+    type: 'audio'
+  },
+  asf: {
+    type: 'video'
+  },
+  asp: {
+    type: 'code'
+  },
+  aspx: {
+    type: 'code'
+  },
+  avi: {
+    type: 'video'
+  },
+  bin: {
+    type: 'binary'
+  },
+  bmp: {
+    type: 'image'
+  },
+  c: {
+    type: 'code'
+  },
+  cpp: {
+    type: 'code'
+  },
+  cs: {
+    type: 'code'
+  },
+  css: {
+    type: 'code'
+  },
+  csv: {
+    type: 'spreadsheet'
+  },
+  cue: {
+    type: 'document'
+  },
+  dll: {
+    type: 'settings'
+  },
+  dmg: {
+    type: 'drive'
+  },
+  doc: {
+    color: '#2C5898',
+    foldColor: '#254A80',
+    glyphColor: 'rgba(255,255,255,0.4)',
+    labelColor: '#2C5898',
+    labelUppercase: true,
+    type: 'document'
+  },
+  docx: {
+    color: '#2C5898',
+    foldColor: '#254A80',
+    glyphColor: 'rgba(255,255,255,0.4)',
+    labelColor: '#2C5898',
+    labelUppercase: true,
+    type: 'document'
+  },
+  dwg: {
+    type: 'vector'
+  },
+  dxf: {
+    type: 'vector'
+  },
+  eot: {
+    type: 'font'
+  },
+  eps: {
+    type: 'vector'
+  },
+  exe: {
+    type: 'settings'
+  },
+  flac: {
+    type: 'audio'
+  },
+  flv: {
+    type: 'video'
+  },
+  fnt: {
+    type: 'font'
+  },
+  fodp: {
+    type: 'presentation'
+  },
+  fods: {
+    type: 'spreadsheet'
+  },
+  fodt: {
+    type: 'document'
+  },
+  fon: {
+    type: 'font'
+  },
+  gif: {
+    type: 'image'
+  },
+  gz: {
+    type: 'compressed'
+  },
+  htm: {
+    type: 'code'
+  },
+  html: {
+    type: 'code'
+  },
+  indd: {
+    color: '#4B2B36',
+    gradientOpacity: 0,
+    labelColor: '#4B2B36',
+    labelTextColor: '#FF408C',
+    labelUppercase: true,
+    foldColor: '#FF408C',
+    radius: 2
+  },
+  ini: {
+    type: 'settings'
+  },
+  java: {
+    type: 'code'
+  },
+  jpeg: {
+    type: 'image'
+  },
+  jpg: {
+    type: 'image'
+  },
+  js: {
+    type: 'code'
+  },
+  json: {
+    type: 'code'
+  },
+  jsx: {
+    type: 'code'
+  },
+  m4a: {
+    type: 'audio'
+  },
+  m4v: {
+    type: 'video'
+  },
+  max: {
+    type: '3d'
+  },
+  md: {
+    type: 'document'
+  },
+  mid: {
+    type: 'audio'
+  },
+  mkv: {
+    type: 'video'
+  },
+  mov: {
+    type: 'video'
+  },
+  mp3: {
+    type: 'audio'
+  },
+  mp4: {
+    type: 'video'
+  },
+  mpeg: {
+    type: 'video'
+  },
+  mpg: {
+    type: 'video'
+  },
+  obj: {
+    type: '3d'
+  },
+  odp: {
+    type: 'presentation'
+  },
+  ods: {
+    type: 'spreadsheet'
+  },
+  odt: {
+    type: 'document'
+  },
+  ogg: {
+    type: 'audio'
+  },
+  ogv: {
+    type: 'video'
+  },
+  otf: {
+    type: 'font'
+  },
+  pdf: {
+    type: 'acrobat'
+  },
+  php: {
+    type: 'code'
+  },
+  pkg: {
+    type: '3d'
+  },
+  plist: {
+    type: 'settings'
+  },
+  png: {
+    type: 'image'
+  },
+  ppt: {
+    color: '#D14423',
+    foldColor: '#AB381D',
+    glyphColor: 'rgba(255,255,255,0.4)',
+    labelColor: '#D14423',
+    labelUppercase: true,
+    type: 'presentation'
+  },
+  pptx: {
+    color: '#D14423',
+    foldColor: '#AB381D',
+    glyphColor: 'rgba(255,255,255,0.4)',
+    labelColor: '#D14423',
+    labelUppercase: true,
+    type: 'presentation'
+  },
+  pr: {
+    type: 'video'
+  },
+  ps: {
+    type: 'vector'
+  },
+  psd: {
+    color: '#34364E',
+    gradientOpacity: 0,
+    labelColor: '#34364E',
+    labelTextColor: '#31C5F0',
+    labelUppercase: true,
+    foldColor: '#31C5F0',
+    radius: 2
+  },
+  py: {
+    type: 'code'
+  },
+  rar: {
+    type: 'compressed'
+  },
+  rb: {
+    type: 'code'
+  },
+  rm: {
+    type: 'video'
+  },
+  rtf: {
+    type: 'document'
+  },
+  scss: {
+    type: 'code'
+  },
+  sitx: {
+    type: 'compressed'
+  },
+  svg: {
+    type: 'vector'
+  },
+  swf: {
+    type: 'video'
+  },
+  sys: {
+    type: 'settings'
+  },
+  tar: {
+    type: 'compressed'
+  },
+  tex: {
+    type: 'document'
+  },
+  tif: {
+    type: 'image'
+  },
+  tiff: {
+    type: 'image'
+  },
+  ts: {
+    type: 'code'
+  },
+  ttf: {
+    type: 'font'
+  },
+  txt: {
+    type: 'document'
+  },
+  wav: {
+    type: 'audio'
+  },
+  webm: {
+    type: 'video'
+  },
+  wmv: {
+    type: 'video'
+  },
+  woff: {
+    type: 'font'
+  },
+  wpd: {
+    type: 'document'
+  },
+  wps: {
+    type: 'document'
+  },
+  xlr: {
+    type: 'spreadsheet'
+  },
+  xls: {
+    color: '#1A754C',
+    foldColor: '#16613F',
+    glyphColor: 'rgba(255,255,255,0.4)',
+    labelColor: '#1A754C',
+    labelUppercase: true,
+    type: 'spreadsheet'
+  },
+  xlsx: {
+    color: '#1A754C',
+    foldColor: '#16613F',
+    glyphColor: 'rgba(255,255,255,0.4)',
+    labelColor: '#1A754C',
+    labelUppercase: true,
+    type: 'spreadsheet'
+  },
+  yml: {
+    type: 'code'
+  },
+  zip: {
+    type: 'compressed'
+  },
+  zipx: {
+    type: 'compressed'
+  }
+};

--- a/src/components/defaultStyles/index.js
+++ b/src/components/defaultStyles/index.js
@@ -1,8 +1,10 @@
 export default {
   '3dm': {
+    labelColor: '#8D1A11',
     type: '3d'
   },
   '3ds': {
+    labelColor: '#5FB9AD',
     type: '3d'
   },
   '3g2': {
@@ -163,12 +165,14 @@ export default {
     type: 'image'
   },
   js: {
+    labelColor: '#F7DF1E',
     type: 'code'
   },
   json: {
     type: 'code'
   },
   jsx: {
+    labelColor: '#00D8FF',
     type: 'code'
   },
   m4a: {
@@ -178,6 +182,7 @@ export default {
     type: 'video'
   },
   max: {
+    labelColor: '#5FB9AD',
     type: '3d'
   },
   md: {
@@ -226,9 +231,11 @@ export default {
     type: 'font'
   },
   pdf: {
+    labelColor: '#D93831',
     type: 'acrobat'
   },
   php: {
+    labelColor: '#8892BE',
     type: 'code'
   },
   pkg: {
@@ -272,12 +279,14 @@ export default {
     radius: 2
   },
   py: {
+    labelColor: '#FFDE57',
     type: 'code'
   },
   rar: {
     type: 'compressed'
   },
   rb: {
+    labelColor: '#BB271A',
     type: 'code'
   },
   rm: {
@@ -287,6 +296,7 @@ export default {
     type: 'document'
   },
   scss: {
+    labelColor: '#C16A98',
     type: 'code'
   },
   sitx: {
@@ -314,6 +324,7 @@ export default {
     type: 'image'
   },
   ts: {
+    labelColor: '#3478C7',
     type: 'code'
   },
   ttf: {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,2 +1,4 @@
 import FileIcon from './FileIcon';
+
 export default FileIcon;
+export { default as defaultStyles } from './defaultStyles/index';


### PR DESCRIPTION
A partial solution to the ask in #8. I'm hesitant to provide too much style when only an `extension` is provided (rather add styles instead of cancelling them out)

Instead I think we can export an object of base styles that can be added to and spread over the component as needed.

At this point I tried to provide the most helpful yet least assuming styles as possible (read: usually just `type` so the icon is correct)

If this looks like it'll do the trick I'll go through and add some `labelColor` keys in 👍 